### PR TITLE
[G2M] Distinguish issues from PRs and better daily updated commit links

### DIFF
--- a/sources/github.js
+++ b/sources/github.js
@@ -105,7 +105,7 @@ const getPRsCommits = ({ prs, start, end }) => Promise.all(prs.map(
     return ((committed >= _start) && (committed <= _end)) // committed within range
       || [created, committed].map((o) => o.toMillis()).includes(updated.toMillis()) // updated == (created | committed)
       || isClosed(pr) && (closed >= updated) // PR closed and not updated after closing
-  }).map((r) => ({ ...r, pull_request_url: pr.pull_request_url }))),
+  }).map((r) => ({ ...r, pull_request_url: pr.pull_request_url, pr_html_url: `${pr.html_url}/commits/${r.sha}` }))),
 )).then((data) => data.flat())
 
 const isPR = (v) => Object.keys(v).includes('pull_request')
@@ -265,7 +265,7 @@ const formatAggComments = ({ enriched_comments: items }) => {
 const formatAggCommits = ({ enriched_commits: items }) => {
   const type = items.length === 1 ? 'commit' : 'commits'
   const users = Array.from(new Set(items.map(({ author }) => author?.login).filter((v) => v)))
-  const links = items.map(({ html_url, sha }) => `[${sha.slice(0, 7)}](${html_url})`)
+  const links = items.map(({ html_url, pr_html_url, sha }) => `[${sha.slice(0, 7)}](${pr_html_url || html_url})`)
   return `${items.length} updated ${type}${users.size ? ` by ${users.join(', ')}` : ''} (${links.join(', ')})`
 }
 const formatAggReviews = ({ enriched_reviews: items }) => {

--- a/sources/github.js
+++ b/sources/github.js
@@ -218,12 +218,10 @@ const formatUser = (issue) => {
   }
   return `(c: ${creator}, a: ${issue.assignees.map((i) => i.login).join(', ')})`
 }
-
 const trimTitle = ({ title }) => ((title.match(REGEX_TITLE).groups || {}).trimmed || title).trim()
-
 const getID = ({ html_url }) => html_url.split(/\/issues\/|\/pull\//)[1]
-
-const composeItem = (item) => [stateIcon(item), `[#${getID(item)}](${item.html_url})`, trimTitle(item), formatUser(item)]
+const itemLink = (item) => `[${item.enriched_commits ? 'PR' : 'Issue'} #${getID(item)}](${item.html_url})`
+const composeItem = (item) => [stateIcon(item), itemLink(item), trimTitle(item), formatUser(item)]
 const formatItem = (item) => composeItem(item).join(' ')
 const formatSub = (sub) => composeItem(sub).slice(1, 3).join(' ')
 
@@ -268,7 +266,7 @@ const formatAggCommits = ({ enriched_commits: items }) => {
   const type = items.length === 1 ? 'commit' : 'commits'
   const users = Array.from(new Set(items.map(({ author }) => author?.login).filter((v) => v)))
   const links = items.map(({ html_url, sha }) => `[${sha.slice(0, 7)}](${html_url})`)
-  return `${items.length} ${type}${users.size ? ` by ${users.join(', ')}` : ''} (${links.join(', ')})`
+  return `${items.length} updated ${type}${users.size ? ` by ${users.join(', ')}` : ''} (${links.join(', ')})`
 }
 const formatAggReviews = ({ enriched_reviews: items }) => {
   const type = items.length === 1 ? 'review' : 'reviews'


### PR DESCRIPTION
Issues and PRs are properly prefixed in both items and sub-items (eg PR associated issues)
![issue-pr](https://user-images.githubusercontent.com/2837532/102807548-dd2b0a80-438c-11eb-926c-75fdfd1af6ce.png)

the commit links appear in daily previously would be of the PR commit-by-commit view:
```
https://github.com/EQWorks/react-maps/pull/42/commits/3c9c4c5c1ed9e1bd62697561caab0bda18fbf7b7
```

instead of the independent commit link:
```
https://github.com/EQWorks/react-maps/commit/3c9c4c5c1ed9e1bd62697561caab0bda18fbf7b7
```

