### PR TITLE
[G2M] github - include lone repo updates (sans-issues/prs)

### DIFF
--- a/daily.js
+++ b/daily.js
@@ -1,7 +1,7 @@
 const { DateTime } = require('luxon')
 
 const {
-  sources: { github: { issuesByRange, enrichIssues, ignoreProjects, ignoreBotUsers, formatPreviously } },
+  sources: { github: { issuesByRange, reposByRange, enrichIssues, ignoreProjects, ignoreBotUsers, formatPreviously } },
   targets: { slack: { uploadMD } },
 } = require('.')
 
@@ -17,10 +17,14 @@ const dailyPreviously = () => {
   const start = stripMS(lastYst.startOf('day').toUTC())
   const end = stripMS(yst.endOf('day').toUTC())
 
-  issuesByRange({ start, end })
-    .then((issues) => issues.filter(ignoreProjects))
-    .then((issues) => issues.filter(ignoreBotUsers))
-    .then((issues) => enrichIssues({ issues, start, end }))
+  Promise.all([
+    issuesByRange({ start, end })
+      .then((issues) => issues.filter(ignoreProjects))
+      .then((issues) => issues.filter(ignoreBotUsers))
+      .then((issues) => enrichIssues({ issues, start, end })),
+    reposByRange({ start, end })
+      .then((issues) => issues.filter(ignoreProjects)),
+  ]).then(([issues, repos]) => ({ repos, ...issues }))
     .then(formatPreviously)
     .then(uploadMD())
     .then(console.log)


### PR DESCRIPTION
hypothetically this would look like below (except none of the previous updates where "lone", or without issues/PRs). this is an effort to capture more potential signals _even_ before everyone gets on board of the PR/issues workflow

![hypo](https://user-images.githubusercontent.com/2837532/103825664-3eb4cf80-5043-11eb-8b01-a98afaa27937.png)
 