### PR TITLE
[G2M] github - lone repo updates to factor in teams and format by prod category

### DIFF
--- a/sources/github/api.js
+++ b/sources/github/api.js
@@ -49,10 +49,10 @@ module.exports.getIssuesComments = this.getIssueEnrichment('comments_url')
 
 module.exports.getPRsReviews = this.getIssueEnrichment('review_comments_url')
 
-module.exports.getRepoTopics = (issues) => Promise.all(
-  issues.reduce((acc, { repository_url }) => {
-    if (acc.indexOf(repository_url) < 0) {
-      acc.push(repository_url)
+module.exports.getTopics = (key) => (collections) => Promise.all(
+  collections.reduce((acc, curr) => {
+    if (acc.indexOf(curr[key]) < 0) {
+      acc.push(curr[key])
     }
     return acc
   }, []).map((v) => client.request({

--- a/sources/github/util.js
+++ b/sources/github/util.js
@@ -24,6 +24,14 @@ module.exports.groupByCatProj = (acc, curr) => {
   return acc
 }
 
+module.exports.groupByCat = (acc, curr) => {
+  const { category = 'meta-uncategorized' } = curr
+  const cat = category.substring(5).toUpperCase()
+  acc[cat] = acc[cat] || []
+  acc[cat].push(curr)
+  return acc
+}
+
 module.exports.formatDates = ({ start, end }) => {
   const _start = DateTime.fromISO(start, { zone: 'UTC' }).setZone(ORG_TZ)
   const _end = DateTime.fromISO(end, { zone: 'UTC' }).setZone(ORG_TZ)

--- a/weekly.js
+++ b/weekly.js
@@ -1,7 +1,7 @@
 const { DateTime } = require('luxon')
 
 const {
-  sources: { github: { issuesByRange, reposByRange, enrichIssues, ignoreProjects, ignoreBotUsers, formatDigest } },
+  sources: { github: { issuesByRange, reposByRange, enrichIssues, enrichRepos, ignoreProjects, ignoreBotUsers, formatDigest } },
   targets: { slack: { uploadMD } },
 } = require('.')
 
@@ -23,8 +23,10 @@ const weeklyDigest = () => {
       .then((issues) => issues.filter(ignoreBotUsers))
       .then((issues) => enrichIssues({ issues, start, end, team })),
     reposByRange({ start, end })
-      .then((issues) => issues.filter(ignoreProjects)),
-  ]).then(([issues, repos]) => ({ repos, ...issues }))
+      .then((repos) => repos.filter(ignoreProjects))
+      .then((repos) => enrichRepos({ repos, team })),
+  ])
+    .then(([issues, repos]) => ({ repos, ...issues }))
     .then(formatDigest)
     .then(uploadMD())
     .then(console.log)


### PR DESCRIPTION
- eliminate faux lone repos in a team-context digest
- format lone repo updates by product categories (through repo topics labelling)

after:
![new](https://user-images.githubusercontent.com/2837532/104242363-10f9cd00-542d-11eb-8b6f-d984e8bae975.png)

before:
![old](https://user-images.githubusercontent.com/2837532/104242424-24a53380-542d-11eb-92a0-77ab41fdf2b9.png)
