### PR TITLE
[G2M] improve lone repo formatting, include all PR commit authors, exclude false PR updates

### DIFF
--- a/sources/github/index.js
+++ b/sources/github/index.js
@@ -20,7 +20,10 @@ module.exports.ignoreProjects = ({ html_url }) =>
 
 module.exports.ignoreBotUsers = ({ user: { login } = {} }) => !login.startsWith('dependabot')
 
-module.exports.enrichIssues = async ({ issues, start, end, team }) => {
+module.exports.enrichIssues = async ({ issues: _issues, start, end, team }) => {
+  // filter stale PRs likely being deleted after being closed for a while
+  // TODO: resort to a more reliable way to detect stale PRs
+  const issues = _issues.filter((v) => !v.closed_at || v.closed_at.split('T')[0] >= v.updated_at.split('T')[0])
   // enrich all (issues and PRs) with issue-level comments
   const [topics, comments] = await Promise.all([
     getIssueTopics(issues),

--- a/sources/github/index.js
+++ b/sources/github/index.js
@@ -91,8 +91,9 @@ const formatLoneRepos = ({ all, repos }) => {
     const grouped = loneRepos.reduce(groupByCat, {})
     content += `${loneRepos.length} Lone Repo updates`
     Object.entries(grouped).forEach(([category, items]) => {
-      content += `\n* ${category} - ${items.map(({ name, html_url }) => `[${name}](${html_url})`).join(', ')}\n`
+      content += `\n* ${category} - ${items.map(({ name, html_url }) => `[${name}](${html_url})`).join(', ')}`
     })
+    content += '\n'
   }
   return content
 }

--- a/sources/github/util.js
+++ b/sources/github/util.js
@@ -76,12 +76,14 @@ const stateIcon = ({ state, draft, title }) => {
   return '👀' // looking for review/comment
 }
 const formatUser = (issue) => {
-  const { user: { login: creator } } = issue
+  const { user: { login: creator }, enriched_commits: commits = [] } = issue
+  const committers = (commits || []).map(({ author, committer }) => (author || {}).login || (committer || {}).login).filter((c) => c && c !== creator)
   const assignees = issue.assignees.map((i) => i.login).filter((a) => a !== creator)
+  const creators = [...committers, creator]
   if (!assignees.length) {
-    return `(${creator})`
+    return `(${creators.join(', ')})`
   }
-  return `(c: ${creator}, a: ${issue.assignees.map((i) => i.login).join(', ')})`
+  return `(c: ${creators.join(', ')}, a: ${assignees.join(', ')})`
 }
 const trimTitle = ({ title }) => ((title.match(REGEX_TITLE).groups || {}).trimmed || title).trim()
 const itemLink = (item) => `[${item.enriched_commits ? 'PR' : 'Issue'} #${this.getID(item)}](${item.html_url})`


### PR DESCRIPTION
[after](https://eqworks.slack.com/archives/CCCB6QD9S/p1611000956001200) (lone repo formatting and exclusion of false PR updates due to stale branch deletions):
![after](https://user-images.githubusercontent.com/2837532/104959985-5aa06580-59a1-11eb-91e2-7d892388a3a9.png)

[before](https://eqworks.slack.com/archives/CCCB6QD9S/p1611001497002600):
![before](https://user-images.githubusercontent.com/2837532/104960020-6be97200-59a1-11eb-9fc1-2d83f18f3882.png)

after (inclusion of all PR commit authors and exclusion of false PR updates due to stale branch deletions)
![after2](https://user-images.githubusercontent.com/2837532/104960192-bff45680-59a1-11eb-88f5-951dee47e91b.png)

before:
![before2](https://user-images.githubusercontent.com/2837532/104960107-963b2f80-59a1-11eb-9969-48456de07ba9.png)
