### PR TITLE
[G2M] github - include body where it's applicable (temp format with ↪️ )

### DIFF
--- a/sources/github/index.js
+++ b/sources/github/index.js
@@ -1,7 +1,7 @@
 const { parseRaw } = require('@eqworks/release')
 
 const { searchByRange, getIssuesComments, getPRsReviews, getTopics, getPRsCommits } = require('./api')
-const { pick, trimTitle, isPR, isTeamTopic, groupByCatProj, groupByCat, groupByProj, formatAggStates, getID, formatUsers, formatItem, formatSub, formatAggComments, formatAggCommits, formatAggReviews, isClosed } = require('./util')
+const { pick, trimTitle, isPR, isTeamTopic, groupByCatProj, groupByCat, groupByProj, formatAggStates, getID, formatUsers, formatItem, formatSub, formatAggComments, formatAggCommits, formatAggReviews, formatBody, isClosed } = require('./util')
 const { formatDates } = require('../util')
 const { parseHTMLUrl } = require('./util')
 
@@ -158,6 +158,7 @@ module.exports.formatDigest = ({ repos, issues, prs, start, end, team, onlyClose
                 content += `\n    * ${formatSub(sub)}`
               }
             })
+            content += formatBody(item)
           })
         })
       })
@@ -202,6 +203,7 @@ module.exports.formatPreviously = ({ repos, issues, prs, start, end }) => {
           if (item.enriched_commits?.length) {
             content += `\n    * ${formatAggCommits(item)}`
           }
+          content += formatBody(item)
         })
       })
     })

--- a/sources/github/util.js
+++ b/sources/github/util.js
@@ -89,6 +89,15 @@ const itemLink = (item) => `[${this.isPR(item) ? 'PR' : 'Issue'} #${this.getID(i
 const composeItem = (item) => [stateIcon(item), itemLink(item), this.trimTitle(item), formatUser(item)]
 module.exports.formatItem = (item) => composeItem(item).join(' ')
 module.exports.formatSub = (sub) => composeItem(sub).slice(1, 3).join(' ')
+// TODO: slack post markdown support is horrible, so can't blockquote nor code-block body atm
+module.exports.formatBody = ({ body }) => {
+  if (!body) {
+    return ''
+  }
+  let content = '\n:arrow_right_hook:'
+  content += `\n${body.split('\n').map((v) => v.trim()).filter((v) => v).map((v) => `=== ${v}`).join('\n')}\n`
+  return content
+}
 
 const _uniqueUsers = (key) => (items) => Array.from(new Set(items.map((v) => v[key]?.login).filter((v) => v)))
 const uniqueUsers = _uniqueUsers('user')


### PR DESCRIPTION
the slack post's markdown support is so very limiting 😞

a temp measure but we can revise as we see better options arise (currently blockquote and code-block are both not working properly, both would have been ideal)

![preview](https://user-images.githubusercontent.com/2837532/156465137-4b49e171-cbac-423a-a470-b184959e5500.png)
