### PR TITLE
[G2M] Fix single vacay, remove (revert) PR/issues body formatting in Slack post

### DIFF
--- a/sources/github/index.js
+++ b/sources/github/index.js
@@ -1,7 +1,7 @@
 const { parseRaw } = require('@eqworks/release')
 
 const { searchByRange, getIssuesComments, getPRsReviews, getTopics, getPRsCommits } = require('./api')
-const { pick, trimTitle, isPR, isTeamTopic, groupByCatProj, groupByCat, groupByProj, formatAggStates, getID, formatUsers, formatItem, formatSub, formatAggComments, formatAggCommits, formatAggReviews, formatBody, isClosed } = require('./util')
+const { pick, trimTitle, isPR, isTeamTopic, groupByCatProj, groupByCat, groupByProj, formatAggStates, getID, formatUsers, formatItem, formatSub, formatAggComments, formatAggCommits, formatAggReviews, isClosed } = require('./util')
 const { formatDates } = require('../util')
 const { parseHTMLUrl } = require('./util')
 
@@ -158,7 +158,6 @@ module.exports.formatDigest = ({ repos, issues, prs, start, end, team, onlyClose
                 content += `\n    * ${formatSub(sub)}`
               }
             })
-            content += formatBody(item)
           })
         })
       })
@@ -203,7 +202,6 @@ module.exports.formatPreviously = ({ repos, issues, prs, start, end }) => {
           if (item.enriched_commits?.length) {
             content += `\n    * ${formatAggCommits(item)}`
           }
-          content += formatBody(item)
         })
       })
     })

--- a/sources/github/util.js
+++ b/sources/github/util.js
@@ -89,15 +89,6 @@ const itemLink = (item) => `[${this.isPR(item) ? 'PR' : 'Issue'} #${this.getID(i
 const composeItem = (item) => [stateIcon(item), itemLink(item), this.trimTitle(item), formatUser(item)]
 module.exports.formatItem = (item) => composeItem(item).join(' ')
 module.exports.formatSub = (sub) => composeItem(sub).slice(1, 3).join(' ')
-// TODO: slack post markdown support is horrible, so can't blockquote nor code-block body atm
-module.exports.formatBody = ({ body }) => {
-  if (!body) {
-    return ''
-  }
-  let content = '\n:arrow_right_hook:'
-  content += `\n${body.split('\n').map((v) => v.trim()).filter((v) => v).map((v) => `=== ${v}`).join('\n')}\n`
-  return content
-}
 
 const _uniqueUsers = (key) => (items) => Array.from(new Set(items.map((v) => v[key]?.login).filter((v) => v)))
 const uniqueUsers = _uniqueUsers('user')

--- a/sources/util.js
+++ b/sources/util.js
@@ -17,8 +17,7 @@ const _formatDates = (zone = 'UTC') => ({ start, end }) => {
   let message = `${_start.toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)} to ${_end.toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}`
   if (_start.startOf('day').toMillis() === _end.startOf('day').toMillis()) {
     message = `on ${_start.toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}`
-  }
-  if (_start.startOf('year').toMillis() === _end.startOf('year').toMillis()) {
+  } else if (_start.startOf('year').toMillis() === _end.startOf('year').toMillis()) {
     message = `${_start.toFormat('ccc, MMM dd')} to ${_end.toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}`
   }
   return { message, status }


### PR DESCRIPTION
- fix the leaky `if` statement reformats vacation to always be like a range
- remove `formatBody` for github PRs/issues in slack post, because slack post is seriously bad