### PR TITLE
[G2M] targets - temp workaround of empty slack post (to upload raw md)

### DIFF
--- a/targets/slack.js
+++ b/targets/slack.js
@@ -6,7 +6,12 @@ const web = new WebClient(SLACK_TOKEN)
 
 module.exports.uploadMD = ({ title, content, channels = SLACK_CHANNEL }) => web.files.upload({
   channels,
-  file: Buffer.from(content, 'utf-8'),
   title,
-  filetype: 'post',
+  filename: `${title}.md`,
+  // TODO: Slack Post seems to be malfunctioning
+  // file: Buffer.from(content, 'utf-8'),
+  // filetype: 'post',
+  // TODO: temp workaround as raw markdown upload
+  content,
+  filetype: 'markdown',
 })


### PR DESCRIPTION
a temp measure until we properly port over to notion

![temp](https://user-images.githubusercontent.com/2837532/162255460-8f528512-d685-448d-8ea3-eea6fd9954e7.png)
