### PR TITLE
[G2M] github - v2 (GraphQL) based issues/PR formatPreviously

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -23,11 +23,11 @@ const getDaily = async ({ date, team, raw = false, dryRun = false, timeZone = OR
   const end = stripMS(yst.endOf('day').toUTC())
 
   const [issues, repos, vacays, journals] = await Promise.all([
-    ghGraphQL.updatedIssuesByRange({ start, end })
+    ghGraphQL.issuesByRange({ start, end })
       .then(ghV2.splitIssuesPRs)
       .then((data) => ({ ...data, start, end })),
     gh.reposByRange({ start, end })
-      .then((issues) => issues.filter(gh.ignoreProjects))
+      .then((repos) => repos.filter(gh.ignoreProjects))
       .then((repos) => gh.enrichRepos({ repos, team })),
     asana.getVacays({ after: day.toISODate(), before: day.endOf('week').toISODate() }),
     notion.getJournals({ start, end, isDaily: true }),
@@ -55,66 +55,51 @@ const getWeekly = async ({ date, team, raw = false, dryRun = false, timeZone = O
   const end = stripMS(yst.endOf('day').toUTC())
 
   const [issues, repos, vacays, journals] = await Promise.all([
-    gh.issuesByRange({ start, end })
-      .then((issues) => issues.filter(gh.ignoreProjects))
-      .then((issues) => issues.filter(gh.ignoreBotUsers))
-      .then((issues) => gh.enrichIssues({ issues, start, end, team })),
+    ghGraphQL.issuesByRange({ start, end })
+      .then(ghV2.splitIssuesPRs)
+      .then((data) => ({ ...data, start, end })),
     gh.reposByRange({ start, end })
       .then((repos) => repos.filter(gh.ignoreProjects))
       .then((repos) => gh.enrichRepos({ repos, team })),
     asana.getVacays({ after: lastYst.toISODate(), before: day.endOf('week').toISODate() }),
     notion.getJournals({ start, end }),
   ])
-  const [enriched, releases] = await Promise.all([
-    gh.enrichNLP({ repos, ...issues, vacays, journals }),
-    gh.api.getReleases({ repos, start, end }),
-  ])
+  const releases = await gh.api.getReleases({ repos, start, end })
   if (raw) {
-    return JSON.stringify({ ...enriched, releases })
+    return JSON.stringify({ vacays, repos, releases, issues, journals })
   }
-  const post = gh.formatDigest(enriched)
+  const post = ghV2.formatPreviously({ repos, ...issues })
   gh.formatReleases({ post, releases, pre: true }) // mutates post.content with releases
   asana.formatVacays({ post, vacays, pre: true }) // mutates post.content with vacations
   notion.formatJournals({ post, journals }) // mutates post.content with journals
   if (dryRun) {
-    return post
+    return post.content
   }
   const page = await notionTarget.uploadMD(post, `weekly-${team}`)
   return slack.postSummary({ url: page.url, title: post.title, summary: post.summary })
 }
-const getRange = async ({ date, scope, team, raw = false, dryRun = false, timeZone = ORG_TZ, labels = [] }) => {
+const getRange = async ({ date, scope, raw = false, dryRun = false, timeZone = ORG_TZ }) => {
   // range in ISO string but drops ms portion
   const day = DateTime.fromISO(date).setZone(timeZone, { keepLocalTime: true })
   const start = stripMS(day.startOf(scope).toUTC())
   const end = stripMS(day.endOf(scope).toUTC())
 
   const [issues, repos] = await Promise.all([
-    gh.issuesByRange({ start, end })
-      .then((issues) => issues.filter(gh.ignoreProjects))
-      .then((issues) => issues.filter(gh.ignoreBotUsers))
-      .then((issues) => gh.enrichIssues({ issues, start, end, team })),
+    ghGraphQL.issuesByRange({ start, end })
+      .then(ghV2.splitIssuesPRs)
+      .then((data) => ({ ...data, start, end })),
     gh.reposByRange({ start, end })
       .then((repos) => repos.filter(gh.ignoreProjects))
       .then((repos) => gh.enrichRepos({ repos })),
   ])
-  const [enriched, releases] = await Promise.all([
-    gh.enrichNLP({ repos, ...issues }),
-    gh.api.getReleases({ repos, start, end }),
-  ])
-  // filter issues and PRs by first labels
-  if (labels.length) {
-    const norm = labels.map((label) => label.toLowerCase()) // normalize labels to all lowercase
-    enriched.issues = enriched.issues.filter(({ labels }) => norm.includes(labels[0].toLowerCase()))
-    enriched.prs = enriched.prs.filter(({ labels }) => norm.includes(labels[0].toLowerCase()))
-  }
+  const releases = await gh.api.getReleases({ repos, start, end })
   if (raw) {
-    return JSON.stringify({ ...enriched, releases })
+    return JSON.stringify({ repos, releases, issues })
   }
-  enriched.onlyClosed = ['year', 'quarter', 'month'].includes(scope)
-  const post = gh.formatDigest(enriched)
+  const post = ghV2.formatPreviously({ repos, ...issues })
   gh.formatReleases({ post, releases, pre: true }) // mutates post.content with releases
   if (dryRun) {
-    return post
+    return post.content
   }
   const page = await notionTarget.uploadMD(post, 'range')
   return slack.postSummary({ url: page.url, title: post.title, summary: post.summary })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eqworks/updates",
-  "version": "0.9.0",
+  "version": "1.0.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@eqworks/updates",
-      "version": "0.9.0",
+      "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@eqworks/release": "^3.4.0-alpha.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/updates",
-  "version": "0.9.0",
+  "version": "1.0.0-alpha.0",
   "description": "Tool to retrieve work updates from multiple sources.",
   "main": "index.js",
   "source": "index.js",

--- a/sources/asana/index.js
+++ b/sources/asana/index.js
@@ -82,7 +82,7 @@ module.exports.formatVacays = ({ post, vacays, pre = true }) => {
     return post
   }
   const summary = []
-  let s = 'Vacations\n'
+  let s = '\nVacations\n'
   Object.entries(vacays).forEach(([email, ranges]) => {
     const fr = ranges.map(formatLocalDates(zone)).map(({ message, status }) => {
       let m = `${message} (${status})`

--- a/sources/github/graphql.js
+++ b/sources/github/graphql.js
@@ -98,6 +98,12 @@ const issueNode = `
     }
     totalCount
   }
+  labels(first: 10, orderBy: {field: CREATED_AT, direction: DESC}) {
+    nodes {
+      name
+    }
+    totalCount
+  }
 `
 
 module.exports.issuesByRange = searchByRange({
@@ -192,6 +198,12 @@ module.exports.issuesByRange = searchByRange({
                 number
                 url
                 title
+              }
+              totalCount
+            }
+            labels(first: 10, orderBy: {field: CREATED_AT, direction: DESC}) {
+              nodes {
+                name
               }
               totalCount
             }

--- a/sources/github/graphql.js
+++ b/sources/github/graphql.js
@@ -48,7 +48,7 @@ const issueNode = `
       name
     }
   }
-  assignees(first: 100) {
+  assignees(first: 10) {
     nodes {
       login
       name
@@ -62,7 +62,7 @@ const issueNode = `
   repository {
     name
     url
-    repositoryTopics(first: 100) {
+    repositoryTopics(first: 10) {
       nodes {
         topic {
           name
@@ -90,7 +90,7 @@ const issueNode = `
       createdAt
     }
   }
-  projectsV2(first: 100) {
+  projectsV2(first: 10) {
     nodes {
       number
       url
@@ -123,7 +123,7 @@ module.exports.updatedIssuesByRange = searchByRange({
                 name
               }
             }
-            assignees(first: 100) {
+            assignees(first: 10) {
               nodes {
                 login
                 name
@@ -151,7 +151,7 @@ module.exports.updatedIssuesByRange = searchByRange({
             repository {
               name
               url
-              repositoryTopics(first: 100) {
+              repositoryTopics(first: 10) {
                 nodes {
                   topic {
                     name
@@ -187,7 +187,7 @@ module.exports.updatedIssuesByRange = searchByRange({
               totalCount
               nodes {${issueNode}}
             }
-            projectsV2(first: 100) {
+            projectsV2(first: 10) {
               nodes {
                 number
                 url
@@ -222,7 +222,7 @@ module.exports.reposByRange = searchByRange({
                 url
               }
             }
-            repositoryTopics(first: 100) {
+            repositoryTopics(first: 10) {
               nodes {
                 topic {
                   ... on Topic {

--- a/sources/github/graphql.js
+++ b/sources/github/graphql.js
@@ -100,7 +100,7 @@ const issueNode = `
   }
 `
 
-module.exports.updatedIssuesByRange = searchByRange({
+module.exports.issuesByRange = searchByRange({
   searchQuery: '-author:app/dependabot',
   query: `
     query IssuesQuery($q: String!, $type: SearchType!, $first: Int!, $after: String) {

--- a/sources/github/graphql.js
+++ b/sources/github/graphql.js
@@ -41,6 +41,7 @@ const searchByRange = ({
 
 const issueNode = `
   id
+  number
   author {
     ... on User {
       login
@@ -115,6 +116,7 @@ module.exports.updatedIssuesByRange = searchByRange({
           ... on Issue {${issueNode}}
           ... on PullRequest {
             id
+            number
             author {
               ... on User {
                 login

--- a/sources/github/index.js
+++ b/sources/github/index.js
@@ -238,7 +238,7 @@ module.exports.formatReleases = ({ post, releases, pre = true }) => {
   if (!releases || releases.length === 0) {
     return post
   }
-  let content = `${releases.length} Releases\n`
+  let content = `\n${releases.length} Releases\n`
   const byProjects = releases.reduce(groupByProj, {})
   const summary = []
   Object.entries(byProjects).forEach(([project, items]) => {

--- a/sources/github/v2.js
+++ b/sources/github/v2.js
@@ -52,6 +52,17 @@ const getProjectsV2 = (issue) => {
   return projects
 }
 
+const getLabels = (issue) => ([
+  ...new Set([
+    // seek from direct labels association
+    ...issue?.labels?.nodes?.map(({ name }) => name),
+    // seek from closingIssuesReferences...labels association
+    ...(issue?.closingIssuesReferences?.nodes?.map(({ labels }) => (labels?.nodes || [])) || [])
+      .flat()
+      .map(({ name }) => name),
+  ]),
+])
+
 const getProjectTopics = (repositoryTopics) => {
   const topics = repositoryTopics.nodes.map(({ topic }) => topic?.name)
   let pts = topics.filter((t) => !isTeamTopic(t))
@@ -191,6 +202,11 @@ module.exports.formatPreviously = ({ repos, issues, prs, start, end }) => {
       // format aggregated review stats
       if (i.reviews?.totalCount) {
         content += formatAggDiscussionStats({ discussions: i.reviews, start, end })
+      }
+      // format labels
+      const labels = getLabels(i)
+      if (labels.length) {
+        content += `* Label${labels.length > 1 ? 's' : ''}: ${labels.map((l) => `\`${l}\``).join(', ')}\n`
       }
     })
   })

--- a/sources/github/v2.js
+++ b/sources/github/v2.js
@@ -1,6 +1,6 @@
 const { DateTime } = require('luxon')
 
-const { isTeamTopic } = require('./util')
+const { isTeamTopic, trimTitle } = require('./util')
 
 
 // issues contain both issues and PRs, through __typename
@@ -10,8 +10,141 @@ module.exports.splitIssuesPRs = (data) => {
   // separate out issues without PR links
   const linkedIssueIDs = prs.map(pr => pr.closingIssuesReferences.nodes.map(node => node.id)).flat()
   const issues = data.filter(issue => issue.__typename === 'Issue' && !linkedIssueIDs.includes(issue.id))
+  return { issues, prs }
+}
 
-  return { prs, issues }
+const isWIP = (issue) => !issue.closed && (issue.isDraft || issue.title.toLowerCase().includes('[wip]'))
+
+const formatAggIssuesStates = (issues) => {
+  let r = ''
+  const closed = issues.filter((i) => i.closed).length
+  if (issues.length === closed) {
+    return ' (all done ✔️)'
+  }
+  if (closed) {
+    r += `\n* ✔️ Done: ${closed}`
+  }
+  const wip = issues.filter(isWIP).length
+  if (wip) {
+    r += `\n* ⚠️ WIP: ${wip}`
+  }
+  const rest = issues.length - closed - wip
+  if (rest > 0) {
+    r += `\n* 👀 Needs review: ${rest}`
+  }
+  return r
+}
+
+const getProjectsV2 = (issue) => {
+  let projects = [
+    // seek from direct projectsV2 association
+    ...issue?.projectsV2?.nodes,
+    // seek from closingIssuesReferences...projectsV2 association
+    ...(issue?.closingIssuesReferences?.nodes?.map(({ projectsV2 }) => (projectsV2?.nodes || [])) || []).flat(),
+  ]
+  // dedupe projects by project url
+  projects = projects.filter((p, i) => projects.findIndex(({ url }) => url === p.url) === i)
+  return projects
+}
+
+const getProjectTopics = (repositoryTopics) => {
+  const topics = repositoryTopics.nodes.map(({ topic }) => topic?.name)
+  let pts = topics.filter((t) => !isTeamTopic(t))
+  // dedupe pts by name
+  pts = pts.filter((p, i) => pts.findIndex((name) => name.toLowerCase() === p.toLowerCase()) === i)
+  // conform to the format of projectsV2, signify legacy with the meta- prefix
+  return pts.map((title) => ({ title }))
+}
+
+const stateIcon = (issue) => {
+  if (issue.closed) {
+    return '✔️'
+  }
+  if (isWIP(issue)) {
+    return '⚠️'
+  }
+  return '👀'
+}
+
+const formatIssueType = ({ __typename }) => {
+  if (__typename === 'PullRequest') {
+    return 'PR'
+  }
+  return __typename || 'Issue'
+}
+
+const formatParticipants = (issue) => {
+  let i = issue.author.login // initiator (author)
+  let p = i // participants (initially the initiator)
+  if (issue.assignees?.nodes?.length) {
+    const a = issue.assignees.nodes.map(({ login }) => login).filter(n => n !== i).join(', ')
+    if (a) {
+      p = `Assigned: ${a}, Initiated: ${i}`
+    }
+  }
+  return p
+}
+
+const formatIssueItem = (issue) => {
+  // state icon
+  const prefix = stateIcon(issue)
+  // type with number and URL
+  const type = `[${formatIssueType(issue)} #${issue.number}](${issue.url})`
+  // title with URL
+  const title = trimTitle(issue)
+  // participants
+  const participants = formatParticipants(issue)
+  return `${prefix} ${type} ${title} (${participants})`
+}
+
+// format previously (daily) updates
+module.exports.formatPreviously = ({
+  issues, prs,
+  // start, end, // TODO: include start/end loigc
+}) => {
+  // TODO: format lone repos
+  let summary = ''
+  let content = ''
+  // format summary stats for PRs and issues
+  summary += `${issues.length + prs.length} updates (${prs.length} PRs, ${issues.length} issues)`
+  summary += formatAggIssuesStates([...prs, ...issues])
+  // group by repository, maintain natural order of PRs before issues
+  const byRepo = [...prs, ...issues].reduce((acc, issue) => {
+    const repo = issue.repository.name
+    acc[repo] = {
+      ...issue.repository,
+      issues: [...(acc[repo]?.issues || []), issue],
+    }
+    return acc
+  }, {})
+  // format content for each repo
+  Object.values(byRepo).forEach((repo) => {
+    // console.log(repo)
+    content += `\n## [${repo.name}](${repo.url})\n`
+    // format each PR and issue
+    repo.issues.forEach((i) => {
+      content += `\n${formatIssueItem(i)}\n`
+      // format projects association
+      let projects = getProjectsV2(i)
+      if (!projects.length) {
+        projects = getProjectTopics(i?.repository?.repositoryTopics)
+      }
+      if (projects.length) {
+        content += `* Projects: ${projects.map((p) => {
+          if (p.url) {
+            return `[${trimTitle(p)}](${p.url})`
+          }
+          return trimTitle(p)
+        }).join(', ')}\n`
+      }
+      // format closing issues association
+      if (i.closingIssuesReferences?.nodes?.length) {
+        content += `* Reference issues: ${i.closingIssuesReferences.nodes.map(formatIssueItem).join(', ')}\n`
+      }
+    })
+  })
+
+  return { summary, content }
 }
 
 const getTeamTopicsCategory = (repositoryTopics) => {
@@ -26,7 +159,7 @@ const getTeamTopicsCategory = (repositoryTopics) => {
 module.exports.filterReleasesTeams = ({ team, repos, start, end }) => {
   const _start = DateTime.fromISO(start, { zone: 'UTC' }).startOf('day')
   const _end = DateTime.fromISO(end, { zone: 'UTC' }).startOf('day')
-  
+
   return repos.map(({ releases, repositoryTopics, ...rest }) => {
     const ttc = getTeamTopicsCategory(repositoryTopics)
 


### PR DESCRIPTION
rolling on top of #46 and #47 

all CLI functions should now be more uniform with the universally applied new `v2.formatPreviously()`

further work needed:
- incorporate and adapt v2/GraphQL sourced repos and releases
- refactor CLI (since it's more similar now with the universal `v2.formatPreviously()`)
  - and obviously cleanup work to fully phase out the unused v1/REST sourced github updates

some sample results can be found at https://www.notion.so/eqproduct/7d27b9b8d73a4c738f4bcfc700555d2a?v=1b814269dd0b4a1aa3a556eee9b75e10 (staging/test Notion database) for each type (daily/weekly-team/range), and also corresponding slack summary messages can be found starting from [this one](https://eqworks.slack.com/archives/CCCB6QD9S/p1660164820052669)